### PR TITLE
Add z-depth controls and overlap boundary clipping for rects

### DIFF
--- a/index.html
+++ b/index.html
@@ -1450,6 +1450,7 @@
         <p style="font-size:11px;margin-top:4px;">or drag and drop here</p>
       </div>
       <div id="canvas-wrapper"><canvas id="main-canvas"></canvas></div>
+      <div id="z-tooltip" style="display:none;position:fixed;background:rgba(30,30,30,0.92);color:#fff;font-size:11px;padding:3px 8px;border-radius:4px;pointer-events:none;z-index:9999;white-space:nowrap;"></div>
     </div>
   </div>
 
@@ -2372,6 +2373,7 @@
         if (tool === 'rect' && showLabel) pendingIncLabel = usedLbl;
 
         refreshList(true); refreshCount(); pushHist();
+        if (tool === 'rect') updateOverlapClips();
         activeObj = null;
       });
 
@@ -2439,7 +2441,7 @@
         }
         glueLbl(obj);
         // When a rect moves, also move any block labels anchored to it
-        if (obj._kind === 'rect') glueAnchoredBlocks(obj);
+        if (obj._kind === 'rect') { glueAnchoredBlocks(obj); updateOverlapClips(); }
         // Shift-constrain: lock movement to the dominant axis for lines
         if (shiftHeld && obj._kind === 'line') {
           if (!obj._snapStart) obj._snapStart = { left: obj.left, top: obj.top };
@@ -2453,7 +2455,7 @@
       });
       cv.on('object:scaling', opt => {
         glueLbl(opt.target);
-        if (opt.target._kind === 'rect') glueAnchoredBlocks(opt.target);
+        if (opt.target._kind === 'rect') { glueAnchoredBlocks(opt.target); updateOverlapClips(); }
       });
       cv.on('object:rotating', opt => {
         glueLbl(opt.target);
@@ -2485,6 +2487,7 @@
           const a = annots.find(a => a.shape === obj);
           if (a) snapBlockToRect(a);
         }
+        if (obj && obj._kind === 'rect') updateOverlapClips();
         pushHist();
       });
 
@@ -2510,6 +2513,30 @@
         const p = cv.getPointer(e);
         pasteAnnotationAt(lastSelectedAnn, p.x, p.y);
       });
+
+      // Z-depth control tooltip
+      const zTip = document.getElementById('z-tooltip');
+      cv.upperCanvasEl.addEventListener('mousemove', e => {
+        const obj = cv.getActiveObject();
+        if (!obj || !obj.oCoords) { zTip.style.display = 'none'; return; }
+        const rect = cv.upperCanvasEl.getBoundingClientRect();
+        const mx = e.clientX - rect.left, my = e.clientY - rect.top;
+        let label = null;
+        for (const [key, ctrl] of Object.entries(obj.controls)) {
+          if (!ctrl._zTip) continue;
+          const c = obj.oCoords[key];
+          if (c && Math.hypot(mx - c.x, my - c.y) < 14) { label = ctrl._zTip; break; }
+        }
+        if (label) {
+          zTip.textContent = label;
+          zTip.style.display = 'block';
+          zTip.style.left = (e.clientX + 12) + 'px';
+          zTip.style.top  = (e.clientY - 24) + 'px';
+        } else {
+          zTip.style.display = 'none';
+        }
+      });
+      cv.upperCanvasEl.addEventListener('mouseleave', () => { zTip.style.display = 'none'; });
     }
 
     // ═══════════════════════════════════════════════════════
@@ -2621,13 +2648,81 @@
           copyRight:  ctrl( 0.5,  0,   off,    0, 'right'),
         };
       } else {
+        // Rect: keep standard handles + copy buttons + z-depth controls flanking mtr.
+        const zCtrl = (offsetX, symbol, actionFn, tipKey) => new fabric.Control({
+          x: 0, y: -0.5, offsetX, offsetY: -40,
+          cursorStyle: 'pointer',
+          cornerSize: 20,
+          mouseUpHandler(evtData, transform) {
+            actionFn(transform.target);
+            return true;
+          },
+          render(ctx, left, top, styleOverride, fabricObject) {
+            const size = (fabricObject && fabricObject.cornerSize) || 13;
+            const half = size / 2;
+            ctx.save();
+            ctx.fillStyle   = (fabricObject && fabricObject.cornerColor) || 'rgba(255,255,255,0.92)';
+            ctx.strokeStyle = (fabricObject && fabricObject.cornerStrokeColor) || 'rgba(0,0,0,0.25)';
+            ctx.lineWidth   = 1;
+            ctx.fillRect(left - half, top - half, size, size);
+            ctx.strokeRect(left - half, top - half, size, size);
+            ctx.fillStyle    = 'rgba(0,0,0,0.72)';
+            ctx.font         = `bold ${Math.round(size * 0.85)}px sans-serif`;
+            ctx.textAlign    = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(symbol, left, top + 0.5);
+            ctx.restore();
+          },
+          _zTip: tipKey,
+        });
         obj.controls = Object.assign({}, obj.controls, {
-          copyTop:    ctrl( 0,   -0.5,    0, -off, 'top'),
-          copyBottom: ctrl( 0,    0.5,    0,  off, 'bottom'),
-          copyLeft:   ctrl(-0.5,  0,  -off,    0, 'left'),
-          copyRight:  ctrl( 0.5,  0,   off,    0, 'right'),
+          copyTop:      ctrl( 0,   -0.5,    0, -off, 'top'),
+          copyBottom:   ctrl( 0,    0.5,    0,  off, 'bottom'),
+          copyLeft:     ctrl(-0.5,  0,  -off,    0, 'left'),
+          copyRight:    ctrl( 0.5,  0,   off,    0, 'right'),
+          sendBackward: zCtrl(-35, '↺', t => { cv.sendBackwards(t); updateOverlapClips(); }, 'Send Backward'),
+          bringForward: zCtrl( 35, '↻', t => { cv.bringForward(t);  updateOverlapClips(); }, 'Bring Forward'),
         });
       }
+    }
+
+    // ═══════════════════════════════════════════════════════
+    //  OVERLAP CLIPPING — front rect clips back rect's border
+    // ═══════════════════════════════════════════════════════
+    function updateOverlapClips() {
+      if (!cv) return;
+      const allObjs = cv.getObjects();
+      const rectShapes = annots
+        .filter(a => a.kind === 'rect' && a.shape)
+        .map(a => a.shape)
+        .sort((a, b) => allObjs.indexOf(a) - allObjs.indexOf(b)); // back → front order
+
+      for (let i = 0; i < rectShapes.length; i++) {
+        const back = rectShapes[i];
+        // Collect all rects that are in front of this one and overlap it.
+        const fronts = rectShapes.slice(i + 1).filter(f => back.intersectsWithObject(f) || back.isContainedWithinObject(f) || f.isContainedWithinObject(back));
+
+        if (fronts.length === 0) {
+          back.clipPath = null;
+        } else {
+          // Build inverted clip rect(s) that hide back's stroke inside each front rect.
+          const clips = fronts.map(f => new fabric.Rect({
+            left:   f.left,
+            top:    f.top,
+            width:  f.getScaledWidth(),
+            height: f.getScaledHeight(),
+            angle:  f.angle || 0,
+            absolutePositioned: true,
+          }));
+          if (clips.length === 1) {
+            clips[0].inverted = true;
+            back.clipPath = clips[0];
+          } else {
+            back.clipPath = new fabric.Group(clips, { absolutePositioned: true, inverted: true });
+          }
+        }
+      }
+      cv.renderAll();
     }
 
     function duplicateAnnotation(obj, direction) {
@@ -3054,6 +3149,7 @@
       cv.discardActiveObject();
       cv.renderAll();
       refreshList(); refreshCount(); pushHist();
+      updateOverlapClips();
     }
 
     function clearAll() {
@@ -3524,6 +3620,7 @@
         histLock = false;
         syncHistBtns();
         setTool(tool);
+        updateOverlapClips();
       });
     }
 
@@ -3876,6 +3973,7 @@
             selectedIds.clear();
             refreshList(); refreshCount(); histLock = false;
             pushHist(); syncHistBtns(); setTool(tool);
+            updateOverlapClips();
           };
           const hasBg = cv.getObjects().some(o => o._bg);
           if (!hasBg) {


### PR DESCRIPTION
Z-depth controls (↺ / ↻):
- Two square buttons flank the rotation handle at the top of every selected rect: ↺ (Send Backward, left) and ↻ (Bring Forward, right).
- Each click shifts the rect one step in z-order and immediately recalculates overlap clips.
- Hovering over either button shows a floating tooltip ('Send Backward' / 'Bring Forward') that tracks the mouse cursor.

Overlap boundary clipping (front clips back border):
- updateOverlapClips() iterates all rect annotations sorted by z-order.
- For each rect that has one or more rects in front of it and overlapping it, an inverted Fabric.js clipPath is applied so the back rect's stroke is hidden inside the front rect's area, giving a clean merged-boundary appearance without affecting the background image.
- Multiple front rects are combined as an inverted fabric.Group clipPath.
- Clips are recalculated on: draw, move, scale, modify, delete, z-order change, undo/redo, and session load.

https://claude.ai/code/session_014r6EQnpowfXq1ST34vF1oJ