### PR TITLE
Fix select tool: call setCoords() after drawing rects (Fabric v7 aCoo…

### DIFF
--- a/index.html
+++ b/index.html
@@ -2448,6 +2448,7 @@
         if (tiny) { cv.remove(activeObj); annId--; activeObj = null; return; }
 
         activeObj.set({ selectable: true, evented: true });
+        activeObj.setCoords(); // update hit-detection coords after drawing (Fabric v7 aCoords cache)
         // Fabric.Line does not update width/height/left/top when x2/y2 are changed via
         // set() during drawing — bake them in now so endpoint controls are positioned correctly.
         if (tool === 'line') {
@@ -3300,6 +3301,7 @@
         obj.evented = sel || alwaysSel;
       });
       if (!sel) cv.discardActiveObject();
+      cv.getObjects().forEach(obj => obj.setCoords()); // refresh all hit-detection coords (Fabric v7)
       cv.renderAll();
     }
 


### PR DESCRIPTION
…rds cache bug)

In Fabric v7, getCoords() uses a lazily-initialized aCoords cache that is only updated via explicit setCoords() calls. When a rect is drawn starting at 0x0 and expanded via obj.set(), the aCoords remain 0x0 — causing _checkTarget hit detection to always miss the rect.

- Add activeObj.setCoords() in mouse:up after drawing a rect so its aCoords reflect actual drawn dimensions
- Add cv.getObjects().forEach(obj => obj.setCoords()) in setTool() before renderAll() so all objects have correct coords when entering select mode

https://claude.ai/code/session_014r6EQnpowfXq1ST34vF1oJ