### PR TITLE
Adjacent rect copies share a single border edge (overlap by strokeWidth)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3116,10 +3116,14 @@
       if (!ann) return;
 
       const angle = ((obj.angle || 0) * Math.PI) / 180;
-      // getScaledWidth/Height already include stroke contribution in Fabric.js v5,
-      // so no extra addition is needed — duplicates will touch with zero gap.
-      const W = obj.getScaledWidth();
-      const H = obj.getScaledHeight();
+      // getScaledWidth/Height include strokeWidth in Fabric v6+.
+      // Subtract strokeWidth so the new rect's path edge coincides exactly with the
+      // originating rect's opposite path edge: the two strokes then overlap by one full
+      // strokeWidth, and updateOverlapClips() clips the back border away leaving a
+      // single clean shared edge — exactly like adjacent tissue sections in a cassette.
+      const sw = obj.strokeWidth || 0;
+      const W = obj.getScaledWidth()  - sw;
+      const H = obj.getScaledHeight() - sw;
 
       const center = obj.getCenterPoint();
       const cos = Math.cos(angle), sin = Math.sin(angle);


### PR DESCRIPTION
Previously the offset used getScaledWidth() / getScaledHeight() which is the full bounding-box size including stroke. This placed the new rect so its visual edge just touched the original's visual edge — producing two visible borders side by side with no gap (double line).

Subtracting strokeWidth from the offset places the new rect's path centerline exactly on top of the original's opposite path centerline. The two strokes overlap by exactly one strokeWidth, and updateOverlapClips then clips the back rect's border at that region, leaving a single clean shared edge — matching the cassette model where adjacent tissue sections share the same physical cut face.

The fix works for all four copy-button directions and is correct for both unscaled and scaled rects (strokeUniform:true means the stroke contribution is constant, not multiplied by scaleX/Y).

https://claude.ai/code/session_014r6EQnpowfXq1ST34vF1oJ