### PR TITLE
Fix duplicate labels from copy-button adjacent rects

### DIFF
--- a/index.html
+++ b/index.html
@@ -3623,16 +3623,11 @@
       }
       // Update block label input when a block/lbl/rect annotation is selected.
       // Text objects are free-form labels, not block labels — do not sync them.
-      if (obj._kind === 'block') {
-        const a = annots.find(a => a.shape === obj);
-        if (a && a.label) setLbl(a.label);
-      } else if (obj._kind === 'lbl') {
-        const a = annots.find(a => a.lbl === obj);
-        if (a && a.label) setLbl(a.label);
-      } else if (obj._kind === 'rect') {
-        const a = annots.find(a => a.shape === obj);
-        if (a && a.label) setLbl(a.label);
-      }
+      // NOTE: we do NOT call setLbl(a.label) here. Overwriting the counter with the
+      // selected object's existing label causes duplicates: if the user selects rect "A"
+      // then uses a copy button to create an adjacent rect, getLbl() would return "A"
+      // and the letter-toggle would assign "A" again. The counter is managed solely
+      // by autoInc() and is reset only on canvas clear / session load.
       // Sync ann-item highlights
       document.querySelectorAll('.ann-item').forEach(el => {
         const elId = +el.dataset.id;


### PR DESCRIPTION
When a labeled rect was selected, syncSidebar() called setLbl(a.label) to overwrite the block-label counter with the selected object's existing label. This meant that after selecting rect "A" and pressing a copy- direction button, getLbl() still returned "A" — so the letter-toggle on the new rect would assign "A" again, creating a duplicate.

The counter should only ever be changed by autoInc() (after a label is placed), session restore, and canvas reset. The selected object's label is already read directly from ann.label in every path that needs it (popup, renderLetterBtn _letterActive branch, commitEdit), so these setLbl() sync calls served no functional purpose beyond causing the bug.

Removed the three setLbl(a.label) calls from syncSidebar and replaced them with a comment explaining the invariant.

https://claude.ai/code/session_014r6EQnpowfXq1ST34vF1oJ