### PR TITLE
Fix z-order reverting on deselect by calling bringToFront in selectio…

### DIFF
--- a/index.html
+++ b/index.html
@@ -2595,8 +2595,15 @@
             refreshList();
             const el = document.querySelector(`.ann-item[data-id="${a.id}"]`);
             if (el) el.scrollIntoView({ block: 'nearest' });
-            // Recompute clip paths: the selected rect is treated as frontmost
-            if (obj._kind === 'rect') updateOverlapClips();
+            // Persistently bring the selected rect to the top of the z-order so
+            // that the overlap-clipping stays correct after deselection too.
+            // bringToFront() in Fabric v7 manipulates _objects directly (no add/remove)
+            // and does not clear _activeObject, so it is safe to call synchronously here.
+            if (obj._kind === 'rect') {
+              cv.bringToFront(obj);
+              elevateSpecialObjects();
+              updateOverlapClips();
+            }
             return; // refreshList already called syncSidebar via re-render
           }
         }
@@ -2615,8 +2622,11 @@
             refreshList();
             const el = document.querySelector(`.ann-item[data-id="${a.id}"]`);
             if (el) el.scrollIntoView({ block: 'nearest' });
-            // Recompute clip paths: the selected rect is treated as frontmost
-            if (obj._kind === 'rect') updateOverlapClips();
+            if (obj._kind === 'rect') {
+              cv.bringToFront(obj);
+              elevateSpecialObjects();
+              updateOverlapClips();
+            }
             syncSidebar();
             return;
           }


### PR DESCRIPTION
…n handlers

Previously, the selected rect appeared on top only cosmetically via clip-path override during selection. On deselect, clips reverted to actual z-order which never changed, so overlapping rects would reappear on top.

Fix: call cv.bringToFront() synchronously in selection:created and selection:updated for rect objects, making z-order permanently correct so overlap clips remain valid after deselection.

https://claude.ai/code/session_014r6EQnpowfXq1ST34vF1oJ