### PR TITLE
Fix sendToBack crash, undo non-selectable objects, and color picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -2139,7 +2139,9 @@
 
       // Custom color picker — a "+" swatch that opens the native color wheel.
       // After picking, the swatch shows the chosen color and becomes the active swatch.
-      const addLabel = document.createElement('label');
+      // Use a <div> with an explicit .click() call rather than <label> wrapping, because
+      // zero-size color inputs are not reliably activated by label clicks in all browsers.
+      const addLabel = document.createElement('div');
       addLabel.className = 'swatch swatch-add';
       addLabel.id = 'swatch-add';
       addLabel.title = 'Custom color…';
@@ -2150,17 +2152,20 @@
       const colorInp = document.createElement('input');
       colorInp.type = 'color';
       colorInp.id = 'custom-color-input';
-      colorInp.style.cssText = 'position:absolute;width:0;height:0;opacity:0;pointer-events:none';
-      colorInp.addEventListener('input', function () {
+      colorInp.style.cssText = 'position:fixed;left:-9999px;top:-9999px;width:1px;height:1px;opacity:0';
+      const onColorPick = function () {
         const c = this.value;
         addLabel.style.background = c;
         if (c === '#000000' || c === '#ffffff') addLabel.dataset.border = '1';
         else delete addLabel.dataset.border;
         addLabel.title = c;
         activateSwatch(c, addLabel);
-      });
+      };
+      colorInp.addEventListener('input', onColorPick);
+      colorInp.addEventListener('change', onColorPick); // Safari fires change, not input
 
-      addLabel.appendChild(colorInp);
+      addLabel.addEventListener('click', () => colorInp.click());
+      document.body.appendChild(colorInp); // outside canvas DOM so it never affects layout
       row.appendChild(addLabel);
       customSwatchEl = addLabel;
     })();
@@ -2493,7 +2498,7 @@
         fImg.scaleToWidth(cv.width);
         lockBg(fImg);
         cv.add(fImg);
-        cv.sendToBack(fImg);
+        bgToBack(fImg);
         cv.renderAll();
         pushHist();
       });
@@ -2728,7 +2733,7 @@
           fImg.scaleToWidth(W);
           lockBg(fImg);
           cv.add(fImg);
-          cv.sendToBack(fImg);
+          bgToBack(fImg);
           cv.renderAll();
           pushHist();
           if (afterCb) afterCb();
@@ -3399,6 +3404,13 @@
     function elevateSpecialObjects() {
       if (!cv) return;
       cv.getObjects().filter(o => o.isLegend || o.isTitle).forEach(o => cv.bringToFront(o));
+    }
+
+    // Send an object to z-index 0 (behind all others).
+    // Fabric v7 removed the canvas.sendToBack() alias; manipulate _objects directly.
+    function bgToBack(obj) {
+      const i = cv._objects.indexOf(obj);
+      if (i > 0) { cv._objects.splice(i, 1); cv._objects.unshift(obj); }
     }
 
     // ═══════════════════════════════════════════════════════
@@ -4532,7 +4544,8 @@
             fImg.scaleToWidth(baseW);
             lockBg(fImg);
             cv.add(fImg);
-            cv.sendObjectToBack(fImg);
+            bgToBack(fImg);
+          }).catch(() => {/* bg failed — proceed without it */}).finally(() => {
             finishApply();
           });
         } else {
@@ -4901,7 +4914,7 @@
               fImg.scaleToWidth(cv.width);
               lockBg(fImg);
               cv.add(fImg);
-              cv.sendToBack(fImg);
+              bgToBack(fImg);
               finishLoad();
             });
           } else {


### PR DESCRIPTION
sendToBack / undo non-selectable objects:
- Fabric v7 removed canvas.sendToBack() and canvas.sendObjectToBack() aliases. All four call sites were throwing UnhandledPromiseRejection, causing finishApply() in applySnap() to never execute. This left histLock=true, setTool() uncalled, and the canvas in a broken state after every undo.
- Fix: add bgToBack() helper that manipulates cv._objects directly (index 0), which is the correct Fabric v7 approach. Replaces all four call sites.
- Fix: add .finally() to the FabricImage.fromURL chain in applySnap() so finishApply() is guaranteed to run even if the bg image fails to load.

Color picker not opening:
- Zero-size <input type="color"> (width:0;height:0) is not reliably activated by wrapping <label> clicks in all browsers — some browsers require the input to have non-zero dimensions to show the native picker.
- Fix: change swatch-add from <label> to <div>, move colorInp to document.body (position:fixed off-screen, 1x1px), and add an explicit onclick that calls colorInp.click(). Also add a 'change' listener alongside 'input' for Safari, which fires change but not input.

https://claude.ai/code/session_014r6EQnpowfXq1ST34vF1oJ