### PR TITLE
Block tool: click-inside-rect labels rect, first click away dismisses

### DIFF
--- a/index.html
+++ b/index.html
@@ -2049,6 +2049,7 @@
     let pendingIncLabel = null;  // label used for last-drawn rect, cleared on deselect/next-draw
 
     let txtEditJustExited = false;  // prevents creating new annotation on click-away from IText
+    let blockJustPlaced   = false;  // first click after placing a block dismisses instead of creating
     let drawing = false, ox = 0, oy = 0, activeObj = null;
     let annots = [];   // {id, shape, lbl, color, label, kind, notes, _freeOffset}
     let annId = 0;
@@ -2769,14 +2770,28 @@
         // Flush any pending auto-increment on every canvas click (before the
         // non-background guard) so clicking on a label still increments correctly.
         if (pendingIncLabel !== null) { autoInc(pendingIncLabel); pendingIncLabel = null; }
-        // If the click lands on an existing non-background object (e.g. a resize
-        // handle or label), don't start a new drawing operation.
-        if (opt.target && !opt.target._bg) return;
-        const p = opt.scenePoint;
 
         if (tool === 'block') {
-          // Place block label at click position; editing is via double-click popup,
-          // not inline (use fabric.Text so Fabric's IText editor never intercepts).
+          const p = opt.scenePoint;
+          // Shortcut: clicking INSIDE a rect applies/toggles the block label directly,
+          // exactly like clicking the floating letter button — no floating block is placed.
+          const rectAnn = rectContaining(p.x, p.y);
+          if (rectAnn) {
+            applyLetterToRect(rectAnn);
+            return;
+          }
+          // First click after placing a block dismisses the selection instead of
+          // immediately creating another block (matches rect/text tool behaviour).
+          if (blockJustPlaced) {
+            blockJustPlaced = false;
+            cv.discardActiveObject();
+            cv.renderAll();
+            return;
+          }
+          // Clicks on existing non-background objects (e.g. a block label already
+          // placed) should select that object, not create a new one.
+          if (opt.target && !opt.target._bg) return;
+          // Place a floating block label at the click position.
           const lbl = getLbl();
           const txt = new fabric.Text(lbl, {
             left: p.x, top: p.y,
@@ -2795,14 +2810,17 @@
           cv.renderAll();
           const ann = { id: txt._annId, shape: txt, lbl: null, color, label: lbl, kind: 'block', notes: '' };
           annots.push(ann);
-          // Advance the counter so the next placement gets the next label.
           autoInc(lbl);
-          // If anchor mode is on, snap the block label to the nearest hotpoint
-          // of any rectangle it was placed inside.
           if (anchorMode === 'anchor') snapBlockToRect(ann);
+          blockJustPlaced = true;
           refreshList(true); refreshCount(); pushHist();
           return;
         }
+
+        // If the click lands on an existing non-background object (e.g. a resize
+        // handle or label), don't start a new drawing operation.
+        if (opt.target && !opt.target._bg) return;
+        const p = opt.scenePoint;
 
         if (tool === 'text') {
           // Free-form text — enters editing immediately, not tracked as block
@@ -3233,6 +3251,29 @@
       };
     }
 
+    // Toggle (add or remove) a sequential block label on a rect annotation.
+    // Used by both the floating letter button and the block-tool click-inside-rect shortcut.
+    function applyLetterToRect(ann) {
+      if (!ann || ann.kind !== 'rect') return;
+      if (ann.lbl) {
+        cv.remove(ann.lbl);
+        ann.lbl = null;
+        ann.label = '';
+        ann.noBlock = true;
+      } else {
+        const lbl = getLbl();
+        ann.label = lbl;
+        ann.noBlock = false;
+        ann.lbl = makeLblText(lbl, ann.shape);
+        cv.add(ann.lbl);
+        autoInc(lbl);
+      }
+      cv.renderAll();
+      refreshList();
+      refreshLabelKey();
+      pushHist();
+    }
+
     function addCopyControls(obj) {
       if (!obj._kind || obj.isTitle || obj.isLegend) return;
       const off = 22;
@@ -3362,28 +3403,9 @@
           cornerSize: 22,
           render: makeLetterRender(obj),
           mouseUpHandler(evtData, transform) {
-            const target = transform.target;
-            const ann = annots.find(a => a.shape === target);
+            const ann = annots.find(a => a.shape === transform.target);
             if (!ann) return false;
-            if (ann.lbl) {
-              // Remove attached letter label
-              cv.remove(ann.lbl);
-              ann.lbl = null;
-              ann.label = '';
-              ann.noBlock = true;
-            } else {
-              // Attach next auto-increment letter
-              const lbl = getLbl();
-              ann.label = lbl;
-              ann.noBlock = false;
-              ann.lbl = makeLblText(lbl, target);
-              cv.add(ann.lbl);
-              autoInc(lbl);
-            }
-            cv.renderAll();
-            refreshList();
-            refreshLabelKey();
-            pushHist();
+            applyLetterToRect(ann);
             return true;
           },
         });
@@ -3922,6 +3944,7 @@
     // ═══════════════════════════════════════════════════════
     function setTool(t) {
       tool = t;
+      blockJustPlaced = false; // always reset on tool switch
       ['rect', 'line', 'block', 'text', 'select'].forEach(id => {
         const el = document.getElementById('tool-' + id);
         if (el) el.classList.toggle('active', id === t);


### PR DESCRIPTION
Click inside a rectangle with block tool active:
- Clicking anywhere inside an existing rect now applies/toggles the block label directly (same as clicking the floating letter button) — no floating block label is placed. This is faster and more intuitive for the primary workflow of assigning labels to drawn tissue blocks.
- Extracted applyLetterToRect(ann) helper shared by the letter button control and the new click-inside-rect shortcut, eliminating duplicated logic.

First click away after placing a floating block dismisses instead of creating:
- Added blockJustPlaced flag: set true after placing a floating block, cleared on the next canvas click (which deselects rather than placing).
- Matches the rect and text tool pattern where click-away unselects rather than immediately starting a new object.
- Clicking inside a rect still works immediately (rect label shortcuts bypass the dismiss gate since they are always intentional).
- blockJustPlaced is also reset whenever the tool changes.

https://claude.ai/code/session_014r6EQnpowfXq1ST34vF1oJ