### PR TITLE
Block cursor hint, T-snap, arrow simplification, arrowhead fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -2560,11 +2560,39 @@
     }
     const _origLineRender = fabric.Line.prototype._render;
     fabric.Line.prototype._render = function(ctx) {
-      _origLineRender.call(this, ctx);
-      if (!this._arrowStart && !this._arrowEnd) return;
-      const p  = this.calcLinePoints();
-      const sw = this.strokeWidth || 1;
-      const c  = this.stroke || '#000';
+      // When no arrowheads are present fall through to Fabric's default render.
+      if (!this._arrowStart && !this._arrowEnd) { _origLineRender.call(this, ctx); return; }
+
+      // Arrowhead present: draw a SHORTENED line shaft so the rounded/square line cap
+      // at the tip does not poke through the filled arrowhead triangle.  Then draw
+      // the arrowhead on top.  We draw the shaft ourselves so we can clip the endpoint.
+      const p    = this.calcLinePoints();
+      const sw   = this.strokeWidth || 1;
+      const c    = this.stroke || '#000';
+      const size = Math.max(8, sw * 3.5); // must match drawLineArrowhead
+
+      const dx = p.x2 - p.x1, dy = p.y2 - p.y1;
+      const len = Math.hypot(dx, dy) || 1;
+      const ux = dx / len, uy = dy / len;
+
+      // Pull each arrow-end of the shaft back by ~90 % of arrowhead length so the
+      // shaft tip hides cleanly under the filled triangle (slight overlap prevents gaps).
+      let lx1 = p.x1, ly1 = p.y1, lx2 = p.x2, ly2 = p.y2;
+      if (this._arrowEnd   && len > size) { lx2 -= ux * size * 0.9; ly2 -= uy * size * 0.9; }
+      if (this._arrowStart && len > size) { lx1 += ux * size * 0.9; ly1 += uy * size * 0.9; }
+
+      ctx.save();
+      ctx.strokeStyle = c;
+      ctx.lineWidth   = sw;
+      ctx.lineCap     = this.strokeLineCap  || 'round';
+      ctx.lineJoin    = this.strokeLineJoin || 'round';
+      ctx.setLineDash(Array.isArray(this.strokeDashArray) ? this.strokeDashArray : []);
+      ctx.beginPath();
+      ctx.moveTo(lx1, ly1);
+      ctx.lineTo(lx2, ly2);
+      ctx.stroke();
+      ctx.restore();
+
       if (this._arrowEnd)   drawLineArrowhead(ctx, p.x1, p.y1, p.x2, p.y2, sw, c);
       if (this._arrowStart) drawLineArrowhead(ctx, p.x2, p.y2, p.x1, p.y1, sw, c);
     };
@@ -2881,6 +2909,10 @@
       cv.on('mouse:move', opt => {
         const p = opt.scenePoint;
         lastMousePos = p;
+        // Block tool: show pointer when hovering over a rect to hint that clicking labels it
+        if (tool === 'block' && !drawing) {
+          cv.defaultCursor = rectContaining(p.x, p.y) ? 'pointer' : 'crosshair';
+        }
         if (!drawing || !activeObj) return;
         if (tool === 'rect') {
           let l = ox, t = oy, w = p.x - ox, h = p.y - oy;
@@ -2894,16 +2926,32 @@
             if (dx >= dy) ey = oy;   // horizontal snap
             else          ex = ox;   // vertical snap
           }
-          // Snap the drawing tip to nearby line endpoints
-          const LINE_DRAW_SNAP = 20;
+          // Snap drawing tip to existing line endpoints (tight threshold) or
+          // to the nearest point anywhere on a line (wider threshold when Shift held,
+          // enabling clean T-intersections perpendicular to the existing line).
+          const LINE_DRAW_SNAP    = 20;
+          const LINE_MIDLINE_SNAP = shiftHeld ? 40 : 20;
           const existingLines = annots.filter(a => a.kind === 'line' && a.shape);
-          outer: for (const la of existingLines) {
+          let snapped = false;
+          for (const la of existingLines) {
             const { p1, p2 } = getLineEndpoints(la.shape);
             for (const ep of [p1, p2]) {
               if (Math.hypot(ex - ep.x, ey - ep.y) < LINE_DRAW_SNAP) {
-                ex = ep.x; ey = ep.y; break outer;
+                ex = ep.x; ey = ep.y; snapped = true; break;
               }
             }
+            if (snapped) break;
+          }
+          if (!snapped) {
+            // No endpoint nearby — try snapping to anywhere on a line segment
+            let bestDist = LINE_MIDLINE_SNAP, bestX = ex, bestY = ey;
+            for (const la of existingLines) {
+              const { p1, p2 } = getLineEndpoints(la.shape);
+              const cl = closestPointOnSegment(ex, ey, p1.x, p1.y, p2.x, p2.y);
+              const d  = Math.hypot(ex - cl.x, ey - cl.y);
+              if (d < bestDist) { bestDist = d; bestX = cl.x; bestY = cl.y; }
+            }
+            ex = bestX; ey = bestY;
           }
           activeObj.set({ x2: ex, y2: ey });
         }
@@ -3115,7 +3163,16 @@
         }
         const a = annots.find(a => a.shape === obj || a.lbl === obj);
         if (!a) return;
-        if (a.kind === 'line') { return; } // lines have no text labels
+        if (a.kind === 'line') {
+          // Double-click a line to toggle its arrowhead (same as the arrow button)
+          const obj = a.shape;
+          obj.set({ _arrowEnd: !obj._arrowEnd, _arrowStart: false });
+          obj.dirty = true;
+          refreshList();
+          cv.renderAll();
+          pushHist();
+          return;
+        }
         openEdit(a, opt.e);
       });
 
@@ -3174,18 +3231,12 @@
       ctx.restore();
     }
 
-    // Floating arrowhead cycle control rendered on selected lines
-    const ARROW_CYCLE = ['none', 'end', 'start', 'both'];
-    const ARROW_SYMBOLS = { none: '—', end: '→', start: '←', both: '↔' };
-    function arrowModeOf(obj) {
-      return (obj._arrowStart && obj._arrowEnd) ? 'both'
-           : obj._arrowStart ? 'start'
-           : obj._arrowEnd   ? 'end' : 'none';
-    }
+    // Arrowhead toggle button rendered on selected lines.
+    // Simple on/off: clicking adds or removes a single arrowhead at the line's end.
+    // Double-clicking the line itself does the same (see mouse:dblclick handler).
     function renderArrowBtn(ctx, left, top, styleOverride, fabricObject) {
       const size = 22, half = size / 2, r = 4;
-      const mode = arrowModeOf(fabricObject);
-      const active = mode !== 'none';
+      const active = !!fabricObject._arrowEnd;
       ctx.save();
       ctx.fillStyle   = active ? 'rgba(0,212,184,0.92)' : 'rgba(100,100,100,0.82)';
       ctx.strokeStyle = '#fff';
@@ -3203,7 +3254,7 @@
       ctx.font = `bold ${Math.round(size * 0.68)}px sans-serif`;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      ctx.fillText(ARROW_SYMBOLS[mode], left, top + 0.5);
+      ctx.fillText(active ? '→' : '—', left, top + 0.5);
       ctx.restore();
     }
 
@@ -3370,13 +3421,10 @@
           mouseUpHandler(eventData, transform) {
             const obj = transform.target;
             if (obj._kind !== 'line') return false;
-            const cur  = arrowModeOf(obj);
-            const next = ARROW_CYCLE[(ARROW_CYCLE.indexOf(cur) + 1) % ARROW_CYCLE.length];
-            obj.set({
-              _arrowStart: next === 'start' || next === 'both',
-              _arrowEnd:   next === 'end'   || next === 'both',
-            });
+            // Toggle arrowhead: on → off → on. _arrowStart is never used (no double-ended arrows).
+            obj.set({ _arrowEnd: !obj._arrowEnd, _arrowStart: false });
             obj.dirty = true; // invalidate render cache so patched _render sees new arrow state
+            refreshList(); // update 'Line' ↔ 'Arrow' in sidebar
             cv.renderAll();
             pushHist();
             return true;
@@ -4110,7 +4158,7 @@
 
     // Returns the display label for an annotation in the sidebar list
     function getDispLabel(a) {
-      if (a.kind === 'line') return 'Line';
+      if (a.kind === 'line') return (a.shape && a.shape._arrowEnd) ? 'Arrow' : 'Line';
       if (a.kind === 'rect') {
         if (!a.lbl) return 'Rect';
         const lbl = a.label || '';


### PR DESCRIPTION
Block tool: cursor changes to 'pointer' when hovering over a rect, hinting that clicking will apply the label directly.

Line snap: extend snap-while-drawing to also snap to the nearest point anywhere on an existing line (not just endpoints). Enables clean T-intersections. Shift widens the midline snap threshold from 20→40px to make perpendicular connections easy to target.

Arrow tool: remove the multi-state cycle (none→end→start→both). Arrow is now a simple on/off toggle. Double-clicking any line also toggles its arrowhead. Double-ended arrows are removed entirely. The annotation list shows "Arrow" instead of "Line" when _arrowEnd is set.

Arrowhead rendering: replace the draw-full-line-then-overlay approach with a shortened-shaft draw. The line shaft is pulled back ~90% of the arrowhead length before the filled triangle is drawn on top, so the rounded line cap no longer pokes through the arrowhead at thick stroke widths.

https://claude.ai/code/session_014r6EQnpowfXq1ST34vF1oJ