### PR TITLE
Fix undo by using toObject() instead of toJSON() for Fabric v7

### DIFF
--- a/index.html
+++ b/index.html
@@ -4506,12 +4506,26 @@
     // ═══════════════════════════════════════════════════════
     const JSON_PROPS = ['_bg', '_kind', '_annId', 'isLegend', 'isTitle', '_arrowStart', '_arrowEnd'];
 
+    // Register custom properties with Fabric v7's class-level registry.
+    // In Fabric v7, canvas.toJSON() no longer accepts a propertiesToInclude
+    // argument — the parameter was removed from the TypeScript signature.
+    // canvas.toObject(extraProps) still accepts it and passes it through to
+    // each object's toObject. Additionally, setting FabricObject.customProperties
+    // ensures the deserialization path (fromObject → constructor → set) also
+    // applies these properties back onto every restored instance.
+    if (FabricObject) {
+      FabricObject.customProperties = JSON_PROPS;
+    }
+
     // Return canvas JSON with the background image object stripped out.
     // The bg is always recreated from imgDataURL on load, so embedding
     // the base64 src would make exported files enormous.
+    // MUST use cv.toObject (not cv.toJSON) — Fabric v7's toJSON ignores any
+    // propertiesToInclude argument, so _bg/_kind/_annId would be absent from
+    // every serialized object, breaking bg-filtering and byId reconstruction.
     function getCanvasJSON() {
-      const j = cv.toJSON(JSON_PROPS);
-      j.objects = j.objects.filter(o => !o._bg);
+      const j = cv.toObject(JSON_PROPS);
+      j.objects = (j.objects || []).filter(o => !o._bg);
       return j;
     }
 
@@ -4577,21 +4591,17 @@
 
     function applySnap(snap) {
       histLock = true;
-      // Clear stale object references before loading — old Fabric objects will be
-      // replaced by new ones created by loadFromJSON.
       lastElevatedRect = null;
       lastSelectedAnn  = null;
 
-      cv.loadFromJSON(snap.json).then(() => {
-        // Fabric v7 does not guarantee that unknown custom properties survive loadFromJSON.
-        // Re-apply them from the stored JSON by matching object indices. snap.json has the
-        // bg stripped, so getObjects() indices align 1-to-1 with snap.json.objects.
-        const jsonObjs = snap.json.objects || [];
-        cv.getObjects().forEach((obj, idx) => {
-          const src = jsonObjs[idx];
-          if (src) JSON_PROPS.forEach(k => { if (src[k] !== undefined) obj[k] = src[k]; });
-        });
+      // Explicitly remove all objects before restoring.  Fabric v7's loadFromJSON
+      // does NOT automatically clear the canvas first (unlike older versions), so
+      // without this step old objects and newly-loaded objects coexist, causing
+      // orphaned ghost shapes and incorrect byId index reconstruction.
+      cv.discardActiveObject();
+      cv.getObjects().slice().forEach(o => cv.remove(o));
 
+      cv.loadFromJSON(snap.json).then(() => {
         // snap.json has the bg stripped (getCanvasJSON). Re-add it from imgDataURL
         // so it is always freshly created and locked — avoids _bg property round-trip
         // issues that can leave the background selectable/moveable after undo.


### PR DESCRIPTION
Root cause: Fabric v7's canvas.toJSON() was redefined without a propertiesToInclude parameter. Passing JSON_PROPS to it was silently ignored — _bg, _kind, and _annId were absent from every serialized object. This caused two cascading failures:

1. filter(o => !o._bg) never fired (o._bg === undefined), so the background image was always included in the snapshot JSON.

2. After loadFromJSON, no canvas object had _kind set, so byId was empty, annots rebuilt as [], and setTool() made every object non-selectable.

Fix: switch getCanvasJSON() to use cv.toObject(JSON_PROPS), which still accepts propertiesToInclude and passes it through to each object's toObject() serializer. Also register JSON_PROPS on FabricObject.customProperties so Fabric v7's fromObject() deserialization path applies them back on every restored instance.

Additionally, explicitly remove all canvas objects in applySnap() before calling loadFromJSON(). Fabric v7 does NOT auto-clear the canvas in loadFromJSON (unlike older versions), so without this step old and new objects coexist and any byId lookup finds both. The explicit remove ensures a clean slate regardless of version.

https://claude.ai/code/session_014r6EQnpowfXq1ST34vF1oJ