### PR TITLE
Fix text/block selection UI: teal outline, rotation-only controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -2622,6 +2622,8 @@
       obj.cornerSize         = 10;
       obj.transparentCorners = false;
       obj.padding            = 8;
+      // IText editing cursor border defaults to Fabric's purple-blue; override to teal.
+      if ('editingBorderColor' in obj) obj.editingBorderColor = CTRL_ACCENT;
     }
 
     function applyFabricTheme() {
@@ -3460,14 +3462,10 @@
           copyRight:  ctrl( 0.5,  0,   off,    0, 'right'),
         });
       } else if (obj._kind === 'block' || obj._kind === 'text') {
-        // Block labels and free-form text: keep all standard Fabric handles and
-        // add the same copy buttons used by rect/line.
-        obj.controls = Object.assign({}, obj.controls, {
-          copyTop:    ctrl( 0,   -0.5,    0, -off, 'top'),
-          copyBottom: ctrl( 0,    0.5,    0,  off, 'bottom'),
-          copyLeft:   ctrl(-0.5,  0,  -off,    0, 'left'),
-          copyRight:  ctrl( 0.5,  0,   off,    0, 'right'),
-        });
+        // Block labels and free-form text: rotation handle only.
+        // Resize handles and copy buttons are intentionally omitted — font size is
+        // controlled via the sidebar slider, and duplication via the sidebar list.
+        obj.controls = obj.controls.mtr ? { mtr: obj.controls.mtr } : {};
       }
     }
 


### PR DESCRIPTION
1. Text tool outline color: applyCtrlTheme() now also sets editingBorderColor to CTRL_ACCENT (#00d4b8) on IText objects, replacing the default Fabric purple-blue border that appeared while actively editing text.

2. Block and text selection controls: addCopyControls() previously kept all standard Fabric resize handles (tl/tr/bl/br/ml/mr/mt/mb) plus four copy-button controls for block and text objects. Both are now reduced to the rotation handle (mtr) only. Font size is controlled via the sidebar slider; duplication via the sidebar list. Copy buttons remain on rect and line only.

https://claude.ai/code/session_014r6EQnpowfXq1ST34vF1oJ