### PR TITLE
Fix block tool freeze: call setCoords() after replacing controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -3477,6 +3477,11 @@
         // Resize handles and copy buttons are intentionally omitted — font size is
         // controlled via the sidebar slider, and duplication via the sidebar list.
         obj.controls = obj.controls.mtr ? { mtr: obj.controls.mtr } : {};
+        // oCoords is computed from controls and cached; replacing controls does NOT
+        // automatically update oCoords.  findControl() iterates oCoords then looks up
+        // this.controls[key], so stale oCoords keys (tl, tr, bl, br, …) cause
+        // "can't access property shouldActivate, o is undefined" on mouse move.
+        obj.setCoords();
       }
     }
 


### PR DESCRIPTION
Root cause: findControl() iterates this.oCoords (cached corner coords) and looks up this.controls[key] for each entry.  When addCopyControls() replaced the block/text controls object with { mtr } only, oCoords was still stale from the previous full set (tl, tr, bl, br, mt, mb, ml, mr, mtr).  Every non-mtr lookup returned undefined, causing:

  TypeError: can't access property "shouldActivate", o is undefined
  findControl InteractiveObject.ts:231

Fix: call obj.setCoords() immediately after replacing obj.controls so that calcOCoords() rebuilds oCoords from the new mtr-only set.  findControl then only iterates the one key that actually exists in controls.

https://claude.ai/code/session_014r6EQnpowfXq1ST34vF1oJ