### PR TITLE
Fix premature full-handle display on block/text/lbl objects

### DIFF
--- a/index.html
+++ b/index.html
@@ -2871,7 +2871,7 @@
             _kind: 'block', _annId: ++annId,
           });
           cv.add(txt);
-          applyCtrlTheme(txt);
+          addCopyControls(txt);  // restricts to mtr-only immediately (applyCtrlTheme called inside)
           cv.setActiveObject(txt);
           cv.renderAll();
           const ann = { id: txt._annId, shape: txt, lbl: null, color, label: lbl, kind: 'block', notes: '' };
@@ -2901,7 +2901,7 @@
             _kind: 'text', _annId: ++annId,
           });
           cv.add(txt);
-          applyCtrlTheme(txt);
+          addCopyControls(txt);  // restricts to mtr-only (applyCtrlTheme called inside)
           cv.setActiveObject(txt);
           txt.enterEditing();
           cv.renderAll();
@@ -3472,8 +3472,8 @@
           copyLeft:   ctrl(-0.5,  0,  -off,    0, 'left'),
           copyRight:  ctrl( 0.5,  0,   off,    0, 'right'),
         });
-      } else if (obj._kind === 'block' || obj._kind === 'text') {
-        // Block labels and free-form text: rotation handle only.
+      } else if (obj._kind === 'block' || obj._kind === 'text' || obj._kind === 'lbl') {
+        // Block labels, free-form text, and rect letter labels: rotation handle only.
         // Resize handles and copy buttons are intentionally omitted — font size is
         // controlled via the sidebar slider, and duplication via the sidebar list.
         obj.controls = obj.controls.mtr ? { mtr: obj.controls.mtr } : {};


### PR DESCRIPTION
Three related fixes:

1. Block tool: call addCopyControls() at creation (after cv.add) instead of only on mouse:up.  The block was visible with all 8 default resize handles from the moment it appeared until the user released the mouse. Now controls are restricted to mtr-only immediately.

2. Text tool (IText): same — call addCopyControls() at creation rather than relying solely on the editing:exited callback.  Prevents the brief flash of 8 handles if the object becomes visible before editing mode activates.

3. lbl (rect letter labels): addCopyControls() had no case for _kind 'lbl', so these objects kept all default Fabric handles.  Added 'lbl' to the block/text branch so rect letter labels also get mtr-only controls with a setCoords() refresh.

https://claude.ai/code/session_014r6EQnpowfXq1ST34vF1oJ