### PR TITLE
Fix multi-select: correct type string and teal ActiveSelection border

### DIFF
--- a/index.html
+++ b/index.html
@@ -2105,7 +2105,7 @@
       if (!cv) return;
       const obj = cv.getActiveObject();
       if (!obj || obj._bg) return;
-      const sources = obj.type === 'activeSelection' ? obj.getObjects() : [obj];
+      const sources = obj.type === 'ActiveSelection' ? obj.getObjects() : [obj];
       sources.forEach(o => {
         if (o._bg) return;
         if (o._kind === 'rect' || o._kind === 'line') {
@@ -2195,7 +2195,7 @@
       if (!cv) return;
       const obj = cv.getActiveObject();
       if (!obj || obj._bg) return;
-      const sources = obj.type === 'activeSelection' ? obj.getObjects() : [obj];
+      const sources = obj.type === 'ActiveSelection' ? obj.getObjects() : [obj];
       sources.forEach(o => {
         if (!o._bg && (o._kind === 'rect' || o._kind === 'line')) o.set('strokeWidth', strokeW);
       });
@@ -2212,7 +2212,7 @@
       if (!cv) return;
       const obj = cv.getActiveObject();
       if (!obj || obj._bg) return;
-      const sources = obj.type === 'activeSelection' ? obj.getObjects() : [obj];
+      const sources = obj.type === 'ActiveSelection' ? obj.getObjects() : [obj];
       sources.forEach(o => {
         if (o._bg) return;
         if (o._kind === 'text' || o._kind === 'block' || o._kind === 'lbl') {
@@ -2238,7 +2238,7 @@
       if (!cv) return;
       const obj = cv.getActiveObject();
       if (!obj || obj._bg) return;
-      const sources = obj.type === 'activeSelection' ? obj.getObjects() : [obj];
+      const sources = obj.type === 'ActiveSelection' ? obj.getObjects() : [obj];
       const dp = DASH_PATTERNS[style];
       sources.forEach(o => {
         if (!o._bg && (o._kind === 'line' || o._kind === 'rect')) o.set('strokeDashArray', dp);
@@ -3056,6 +3056,8 @@
 
       cv.on('selection:created', opt => {
         const obj = cv.getActiveObject();
+        // Apply teal theme to multi-selection box (ActiveSelection is its own object instance)
+        if (obj && obj.type === 'ActiveSelection') applyCtrlTheme(obj);
         if (obj && !obj._bg) {
           const a = annots.find(a => a.shape === obj || a.lbl === obj);
           if (a) {
@@ -3077,6 +3079,7 @@
         // Flush pending increment when user moves to a different object
         if (pendingIncLabel !== null) { autoInc(pendingIncLabel); pendingIncLabel = null; }
         const obj = cv.getActiveObject();
+        if (obj && obj.type === 'ActiveSelection') applyCtrlTheme(obj);
         if (obj && !obj._bg) {
           const a = annots.find(a => a.shape === obj || a.lbl === obj);
           if (a) {
@@ -4132,7 +4135,7 @@
 
       const obj = cv.getActiveObject();
       if (obj && !obj._bg) {
-        const sources = obj.type === 'activeSelection' ? obj.getObjects() : [obj];
+        const sources = obj.type === 'ActiveSelection' ? obj.getObjects() : [obj];
         sources.forEach(o => {
           if (o._bg) return;
           if (o.isTitle) {
@@ -4786,7 +4789,7 @@
       if (!cv) return;
       const obj = cv.getActiveObject();
       if (!obj) return;
-      const sources = obj.type === 'activeSelection' ? obj.getObjects() : [obj];
+      const sources = obj.type === 'ActiveSelection' ? obj.getObjects() : [obj];
       const valid = sources
         .filter(o => !o._bg && (o._kind === 'rect' || o._kind === 'line' || o._kind === 'text' || o._kind === 'block'))
         .map(o => annots.find(a => a.shape === o))


### PR DESCRIPTION
Two bugs fixed:

1. Wrong type string: Fabric.js v7 uses 'ActiveSelection' (capital A and S) but every multi-select check used 'activeSelection' (all lower). This caused ALL sidebar operations (color, stroke width, font size, line style) and delete/copy to silently treat multi-selections as a single unknown object and do nothing.  Replaced all 6 occurrences.

2. ActiveSelection box color: the multi-selection bounding box showed Fabric's default purple/blue border.  ActiveSelection is its own object instance with its own borderColor, so the per-object applyCtrlTheme() calls on child objects didn't affect it.  Added applyCtrlTheme(obj) in both selection:created and selection:updated when the active object is an ActiveSelection.

https://claude.ai/code/session_014r6EQnpowfXq1ST34vF1oJ